### PR TITLE
Update react peer dependency to include react 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "webpack": "^3.11.0"
   },
   "peerDependencies": {
-    "react": ">=15.0.0 <= 16",
-    "react-dom": ">=15.0.0 <= 16"
+    "react": ">=15.0.0 <= 17",
+    "react-dom": ">=15.0.0 <= 17"
   },
   "scripts": {
     "dev": "webpack --watch",


### PR DESCRIPTION
There are “No New Changes” in react 17 (https://reactjs.org/blog/2020/10/20/react-v17.html), so there should be no issue with bumping up this peer dependency from 16 to 17.